### PR TITLE
20201027 use external lookup client

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,10 @@ You also need to specify the access token::
 
     export DTOOL_LOOKUP_SERVER_TOKEN=$(flask user token olssont)
 
+For testing purposes, it is possible to disable SSL certificates validation with::
+
+    export DTOOL_LOOKUP_CLIENT_IGNORE_SSL=true
+
 Looking up datasets by UUID
 ---------------------------
 

--- a/dtool_lookup_client/__init__.py
+++ b/dtool_lookup_client/__init__.py
@@ -1,5 +1,6 @@
 """dtool_lookup_client package."""
 
+from asgiref.sync import async_to_sync
 import click
 import json
 import requests
@@ -14,14 +15,44 @@ import dtoolcore
 import dtoolcore.utils
 import dtool_config.cli
 
+from dtool_lookup_gui.LookupClient import LookupClient
+
 CONFIG_PATH = dtoolcore.utils.DEFAULT_CONFIG_PATH
 
 DTOOL_LOOKUP_SERVER_URL_KEY = "DTOOL_LOOKUP_SERVER_URL"
 DTOOL_LOOKUP_SERVER_TOKEN_KEY = "DTOOL_LOOKUP_SERVER_TOKEN"
+DTOOL_LOOKUP_SERVER_USERNAME_KEY = "DTOOL_LOOKUP_SERVER_USERNAME"
+DTOOL_LOOKUP_SERVER_PASSWORD_KEY = "DTOOL_LOOKUP_SERVER_PASSWORD"
 
 DTOOL_LOOKUP_CLIENT_IGNORE_SSL_KEY = "DTOOL_LOOKUP_CLIENT_IGNORE_SSL"
 
 __version__ = "0.1.0"
+
+
+async def connect():
+    lookup_url = dtoolcore.utils.get_config_value(DTOOL_LOOKUP_SERVER_URL_KEY)
+    if lookup_url is None:
+        raise RuntimeError('Please provide {}'.format(DTOOL_LOOKUP_SERVER_URL_KEY))
+
+    auth_url = dtoolcore.utils.get_config_value(DTOOL_LOOKUP_SERVER_TOKEN_KEY)
+    if auth_url is None:
+        raise RuntimeError('Please provide {}'.format(DTOOL_LOOKUP_SERVER_TOKEN_KEY))
+
+    username = dtoolcore.utils.get_config_value(DTOOL_LOOKUP_SERVER_USERNAME_KEY)
+    if username is None:
+        raise RuntimeError('Please provide {}'.format(DTOOL_LOOKUP_SERVER_USERNAME_KEY))
+
+    password = dtoolcore.utils.get_config_value(DTOOL_LOOKUP_SERVER_PASSWORD_KEY)
+    if username is None:
+        raise RuntimeError('Please provide {}'.format(DTOOL_LOOKUP_SERVER_PASSWORD_KEY))
+
+    lookup_client = LookupClient(lookup_url, auth_url, username, password)
+
+    await lookup_client.connect()
+
+    return lookup_client
+    # self.server_config = await self.lookup.config()
+    #    self.datasets = await self.lookup.all()
 
 
 def json_serial(obj):
@@ -32,7 +63,7 @@ def json_serial(obj):
 
 def uris_from_lookup_response(response):
     """Return list of URIs from  response from /lookup_datasets/<uuid>."""
-    return [item["uri"] for item in response.json()]
+    return [item["uri"] for item in response]
 
 
 def urljoin(*args):
@@ -51,20 +82,19 @@ def _get_authorisation_header_value():
     return "Bearer {}".format(token)
 
 
+@async_to_sync
+async def async_lookup(uuid):
+    lookup_client = await connect()
+    r = await lookup_client.by_uuid(uuid)
+    await lookup_client.session.close()  # TODO: shouldn't that happen transparently elsewhere?
+    return r
+
+
 @click.command()
 @click.argument("uuid")
 def lookup(uuid):
     """Return the URIs associated with a UUID in the lookup server."""
-    server = dtoolcore.utils.get_config_value(DTOOL_LOOKUP_SERVER_URL_KEY)
-    if server is not None:
-        raise RuntimeError('Please provide {}'.format(DTOOL_LOOKUP_SERVER_URL_KEY))
-    verify = not dtoolcore.utils.get_config_value(
-        DTOOL_LOOKUP_CLIENT_IGNORE_SSL_KEY, default=False)
-    url = urljoin(server, "dataset", "lookup", uuid)
-    headers = {
-        "Authorization": _get_authorisation_header_value(),
-    }
-    r = requests.get(url, headers=headers, verify=verify)
+    r = async_lookup(uuid)
     for uri in uris_from_lookup_response(r):
         click.secho(uri)
 
@@ -93,6 +123,35 @@ def search(query, mongosyntax):
     r = requests.post(url, headers=headers, data=query, verify=verify)
 
     formatted_json = json.dumps(json.loads(r.text), indent=2)
+    colorful_json = pygments.highlight(
+        formatted_json,
+        pygments.lexers.JsonLexer(),
+        pygments.formatters.TerminalFormatter())
+
+    click.secho(colorful_json, nl=False)
+
+
+@async_to_sync
+async def async_query(query):
+    lookup_client = await connect()
+    r = await lookup_client.by_query(query)
+    await lookup_client.session.close()  # TODO: shouldn't that happen transparently somewhere else?
+    return r
+
+
+@click.command()
+@click.argument("query", default="")
+@click.option("-m", "--mongosyntax", default=False, is_flag=True)
+def query(query, mongosyntax):
+    """Return the URIs associated with a query in the lookup server."""
+    if not mongosyntax:
+        if query == "":
+            query = "{}"
+        else:
+            query = '{"$text": {"$search": "' + query + '"}}'
+
+    r = async_query(query)
+    formatted_json = json.dumps(r, indent=2)
     colorful_json = pygments.highlight(
         formatted_json,
         pygments.lexers.JsonLexer(),

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     author_email="tjelvar.olsson@jic.ac.uk",
     url=url,
     install_requires=[
+        "asgiref",
         "click",
         "requests",
         "dtoolcore>=3.9.0",
@@ -26,6 +27,7 @@ setup(
             "lookup=dtool_lookup_client:lookup",
             "register=dtool_lookup_client:register",
             "search=dtool_lookup_client:search",
+            "query=dtool_lookup_client:query",
         ],
     },
     download_url="{}/tarball/{}".format(url, version),


### PR DESCRIPTION
This is an experimental suggestion: have CLI and GUI use same underlying LookupClient class.

The purpose of this modification is to offer the same functionality from command line as within the GUI in order to retrieve results in text format for further processing. The introduced `dtool query` allows direct queries via the server's direct mongo plugin https://github.com/IMTEK-Simulation/dtool-lookup-server-direct-mongo-plugin. 

Here a simple example counting all datasets that match a certain query

```
$ dtool query -m '{"creator_username":"hoermann4","readme.mode":"trial"}' | grep frozen_at | wc -l
603
```

and narrowing down the selection by dates or regex patterns

```console
$ dtool query -m '{"creator_username":"hoermann4","readme.mode":"trial", "name": {"$regex":"minimization$"}, "readme.creation_date":{"$gt":"2020-08-05", "$lt": "2020-08-06"}}'
[
  {
    "base_uri": "smb://jh1130",
    "created_at": "Wed, 05 Aug 2020 16:04:32 GMT",
    "creator_username": "hoermann4",
    "dtoolcore_version": "3.17.0",
    "frozen_at": "Mon, 07 Sep 2020 18:21:42 GMT",
    "name": "2020-08-05-17-50-45-127872-lammpsrelaxedboxminimization",
    "tags": [],
    "type": "dataset",
    "uri": "smb://jh1130/3413f464-d955-43a4-9b6b-e239d85eecf1",
    "uuid": "3413f464-d955-43a4-9b6b-e239d85eecf1"
  },
  {
    "base_uri": "smb://jh1130",
    "created_at": "Wed, 05 Aug 2020 16:11:03 GMT",
    "creator_username": "hoermann4",
    "dtoolcore_version": "3.17.0",
    "frozen_at": "Mon, 07 Sep 2020 18:22:48 GMT",
    "name": "2020-08-05-18-07-28-848226-lammpsrelaxedboxminimization",
    "tags": [],
    "type": "dataset",
    "uri": "smb://jh1130/8ce577bf-50dc-4dd9-96cb-aaedd5230826",
    "uuid": "8ce577bf-50dc-4dd9-96cb-aaedd5230826"
  }
]
```